### PR TITLE
Add kubeconfig input for kubernetes authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@
 module "cert_manager" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager"
 
-  name    = "cert-manager"
-  metrics = true
+  name       = "cert-manager"
+  kubeconfig = "..."
+  metrics    = true
 }
 
 module "issuer" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
 
-  name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
-  server = "production"
+  name       = "issuer"
+  email      = "daniel.balcomb@gmail.com"
+  server     = "production"
+  kubeconfig = "..."
 
   ingress = {
     class = "traefik"
@@ -28,10 +30,11 @@ module "issuer" {
 
 ## Inputs
 
-| Name      | Type     | Default | Description                  |
-| --------- | -------- | ------- | ---------------------------- |
-| `name`    | `string` |         | The certificate manager name |
-| `metrics` | `bool`   | `false` | Enable prometheus metrics    |
+| Name         | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `name`       | `string` |         | The certificate manager name               |
+| `kubeconfig` | `string` |         | The Kubernetes configuration file contents |
+| `metrics`    | `bool`   | `false` | Enable prometheus metrics                  |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 module "controller" {
   source = "./modules/controller"
 
-  name    = var.name
-  metrics = var.metrics
+  name       = var.name
+  kubeconfig = var.kubeconfig
+  metrics    = var.metrics
 }

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -9,17 +9,19 @@ responsible for managing the issuance and lifecycle of certificates.
 module "controller" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/controller"
 
-  name    = "cert-manager"
-  metrics = true
+  name       = "cert-manager"
+  kubeconfig = "..."
+  metrics    = true
 }
 ```
 
 ## Inputs
 
-| Name      | Type     | Default | Description                                |
-| --------- | -------- | ------- | ------------------------------------------ |
-| `name`    | `string` |         | The certificate management controller name |
-| `metrics` | `bool`   | `false` | Enable prometheus metrics                  |
+| Name         | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `name`       | `string` |         | The certificate management controller name |
+| `kubeconfig` | `string` |         | The Kubernetes configuration file contents |
+| `metrics`    | `bool`   | `false` | Enable prometheus metrics                  |
 
 ## Outputs
 
@@ -32,5 +34,5 @@ module "controller" {
 ## Notes
 
 - This module currently requires the `kubectl` command-line utility to be
-  installed in the `PATH` and a `kubeconfig` file in the current working
-  directory for *Kubernetes* authentication.
+  installed in the `PATH` and a `kubeconfig` input for *Kubernetes*
+  authentication.

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -3,6 +3,12 @@ data "helm_repository" "main" {
   url  = "https://charts.jetstack.io"
 }
 
+resource "local_file" "kubeconfig" {
+  filename          = "${path.cwd}/kubeconfig"
+  file_permission   = "0644"
+  sensitive_content = var.kubeconfig
+}
+
 resource "null_resource" "definitions" {
   triggers = {
     hash = sha256(file("${path.module}/templates/definitions.yml"))
@@ -16,6 +22,10 @@ resource "null_resource" "definitions" {
     command = "kubectl delete -f ${path.module}/templates/definitions.yml --kubeconfig ${path.cwd}/kubeconfig"
     when    = destroy
   }
+
+  depends_on = [
+    local_file.kubeconfig,
+  ]
 }
 
 resource "kubernetes_namespace" "main" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   type        = string
 }
 
+variable "kubeconfig" {
+  description = "The Kubernetes configuration file contents"
+  type        = string
+}
+
 variable "metrics" {
   description = "Enable prometheus metrics"
   default     = false

--- a/modules/controller/versions.tf
+++ b/modules/controller/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     helm       = ">= 1.0"
     kubernetes = ">= 1.10"
+    local      = ">= 1.4"
     null       = ">= 2.1"
   }
 }

--- a/modules/issuer/README.md
+++ b/modules/issuer/README.md
@@ -10,9 +10,10 @@ server.
 module "issuer" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
 
-  name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
-  server = "production"
+  name       = "issuer"
+  email      = "daniel.balcomb@gmail.com"
+  server     = "production"
+  kubeconfig = "..."
 
   ingress = {
     class = "traefik"
@@ -27,6 +28,7 @@ module "issuer" {
 | `name`          | `string` |           | The certificate issuer name                                  |
 | `email`         | `string` |           | The certificate issuer ACME registration email address       |
 | `server`        | `string` | `staging` | The certificate issuer ACME server address                   |
+| `kubeconfig`    | `string` |           | The Kubernetes configuration file contents                   |
 | `ingress`       | `object` |           | The ingress configuration                                    |
 | `ingress.class` | `string` |           | The ingress class used for automating the validation process |
 
@@ -44,5 +46,5 @@ module "issuer" {
 - This module evaluates the shorthand `production` and `staging` values for the
   `server` variable as the corresponding *Let's Encrypt* environment.
 - This module currently requires the `kubectl` command-line utility to be
-  installed in the `PATH` and a `kubeconfig` file in the current working
-  directory for *Kubernetes* authentication.
+  installed in the `PATH` and a `kubeconfig` input for *Kubernetes*
+  authentication.

--- a/modules/issuer/main.tf
+++ b/modules/issuer/main.tf
@@ -15,6 +15,12 @@ locals {
   })
 }
 
+resource "local_file" "kubeconfig" {
+  filename          = "${path.cwd}/kubeconfig"
+  file_permission   = "0644"
+  sensitive_content = var.kubeconfig
+}
+
 resource "null_resource" "issuer" {
   triggers = {
     file = base64encode(local.issuer)
@@ -28,4 +34,8 @@ resource "null_resource" "issuer" {
     command = format("kubectl --kubeconfig ${path.cwd}/kubeconfig delete -f - <<EOF\n%s\nEOF", base64decode(self.triggers.file))
     when    = destroy
   }
+
+  depends_on = [
+    local_file.kubeconfig,
+  ]
 }

--- a/modules/issuer/variables.tf
+++ b/modules/issuer/variables.tf
@@ -14,6 +14,11 @@ variable "server" {
   type        = string
 }
 
+variable "kubeconfig" {
+  description = "The Kubernetes configuration file contents"
+  type        = string
+}
+
 variable "ingress" {
   description = "The ingress configuration"
   type = object({

--- a/modules/issuer/versions.tf
+++ b/modules/issuer/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    null = ">= 2.1"
+    local = ">= 1.4"
+    null  = ">= 2.1"
   }
 }

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -1,16 +1,18 @@
 module "cert_manager" {
   source = "../../"
 
-  name    = "cert-manager"
-  metrics = true
+  name       = "cert-manager"
+  kubeconfig = "..."
+  metrics    = true
 }
 
 module "issuer" {
   source = "../../modules/issuer"
 
-  name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
-  server = "staging"
+  name       = "issuer"
+  email      = "daniel.balcomb@gmail.com"
+  server     = "staging"
+  kubeconfig = "..."
 
   ingress = {
     class = "traefik"

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   type        = string
 }
 
+variable "kubeconfig" {
+  description = "The Kubernetes configuration file contents"
+  type        = string
+}
+
 variable "metrics" {
   description = "Enable prometheus metrics"
   default     = false


### PR DESCRIPTION
This adds input variables for passing in Kubernetes authentication credentials instead of relying on an existing file that may or may not yet exist.

With different components being split up in to different stacks it may not be possible to rely on the Kubernetes configuration file from the cluster module to exist. It is possible to create the file outside of the module but then the module would be unable to depend on the files existence and would therefore create a race condition.