### PR TITLE
Fix incorrect issuer DNS challenge client ID

### DIFF
--- a/modules/issuer/README.md
+++ b/modules/issuer/README.md
@@ -23,19 +23,20 @@ module "issuer" {
 
 ## Inputs
 
-| Name                           | Type     | Default   | Description                                                  |
-| ------------------------------ | -------- | --------- | ------------------------------------------------------------ |
-| `name`                         | `string` |           | The certificate issuer name                                  |
-| `email`                        | `string` |           | The certificate issuer ACME registration email address       |
-| `server`                       | `string` | `staging` | The certificate issuer ACME server address                   |
-| `kubeconfig`                   | `string` |           | The Kubernetes configuration file contents                   |
-| `ingress`                      | `object` | `null`    | The ingress configuration for HTTP challenges                |
-| `ingress.class`                | `string` |           | The ingress class used for automating the validation process |
-| `dns_zone`                     | `object` | `null`    | The DNS zone configuration for DNS challenges                |
-| `dns_zone.name`                | `string` |           | The DNS zone name                                            |
-| `dns_zone.group`               | `string` |           | The DNS zone group                                           |
-| `dns_service_principal`        | `object` | `null`    | The service principal configuration for DNS challenges       |
-| `dns_service_principal.secret` | `string` |           | The service principal secret                                 |
+| Name                                   | Type     | Default   | Description                                                  |
+| -------------------------------------- | -------- | --------- | ------------------------------------------------------------ |
+| `name`                                 | `string` |           | The certificate issuer name                                  |
+| `email`                                | `string` |           | The certificate issuer ACME registration email address       |
+| `server`                               | `string` | `staging` | The certificate issuer ACME server address                   |
+| `kubeconfig`                           | `string` |           | The Kubernetes configuration file contents                   |
+| `ingress`                              | `object` | `null`    | The ingress configuration for HTTP challenges                |
+| `ingress.class`                        | `string` |           | The ingress class used for automating the validation process |
+| `dns_zone`                             | `object` | `null`    | The DNS zone configuration for DNS challenges                |
+| `dns_zone.name`                        | `string` |           | The DNS zone name                                            |
+| `dns_zone.group`                       | `string` |           | The DNS zone group                                           |
+| `dns_service_principal`                | `object` | `null`    | The service principal configuration for DNS challenges       |
+| `dns_service_principal.application_id` | `string` |           | The service principal client / application ID                |
+| `dns_service_principal.secret`         | `string` |           | The service principal secret                                 |
 
 ## Outputs
 

--- a/modules/issuer/main.tf
+++ b/modules/issuer/main.tf
@@ -23,7 +23,7 @@ locals {
 
     dns = local.dns_challenge ? {
       secret_name     = kubernetes_secret.secret.0.metadata.0.name
-      client_id       = data.azurerm_client_config.main.0.client_id
+      client_id       = var.dns_service_principal.application_id
       subscription_id = data.azurerm_client_config.main.0.subscription_id
       tenant_id       = data.azurerm_client_config.main.0.tenant_id
       zone            = var.dns_zone

--- a/modules/issuer/variables.tf
+++ b/modules/issuer/variables.tf
@@ -40,6 +40,7 @@ variable "dns_service_principal" {
   description = "The service principal configuration for DNS challenges"
   default     = null
   type = object({
-    secret = string
+    application_id = string
+    secret         = string
   })
 }

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -33,6 +33,7 @@ module "issuer_dns" {
   }
 
   dns_service_principal = {
-    secret = "..."
+    application_id = "..."
+    secret         = "..."
   }
 }


### PR DESCRIPTION
This fixes the incorrect usage of the continuous integration service principal client ID instead of the custom client ID for which the secret applies.