### PR TITLE
Upgrade terraform and provider versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install terraform
-      uses: volcano-coffee-company/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v1
       with:
-        version: ~0.12.24
+        terraform_version: 1.0.10
 
     - name: Lint
       run: terraform fmt -check -diff -recursive
@@ -29,9 +29,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install terraform
-      uses: volcano-coffee-company/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v1
       with:
-        version: ~0.12.24
+        terraform_version: 1.0.10
 
     - name: Initialize
       run: terraform init -input=false -backend=false

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,8 +1,3 @@
-data "helm_repository" "main" {
-  name = "jetstack"
-  url  = "https://charts.jetstack.io"
-}
-
 resource "local_file" "kubeconfig" {
   filename          = "${path.cwd}/kubeconfig"
   file_permission   = "0644"
@@ -50,7 +45,7 @@ locals {
 resource "helm_release" "main" {
   name       = var.name
   namespace  = kubernetes_namespace.main.metadata.0.name
-  repository = data.helm_repository.main.metadata.0.name
+  repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
   version    = "0.13"
 

--- a/modules/controller/versions.tf
+++ b/modules/controller/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   required_providers {
-    helm       = ">= 1.0"
-    kubernetes = ">= 1.10"
-    local      = ">= 1.4"
-    null       = ">= 2.1"
+    helm       = "~> 2.3"
+    kubernetes = "~> 2.6"
+    local      = "~> 2.1"
+    null       = "~> 3.1"
   }
 }

--- a/modules/issuer/versions.tf
+++ b/modules/issuer/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 1.0"
 
   required_providers {
-    azurerm    = ">= 2.5"
-    kubernetes = ">= 1.10"
-    local      = ">= 1.4"
-    null       = ">= 2.1"
+    azurerm    = "~> 2.83"
+    kubernetes = "~> 2.6"
+    local      = "~> 2.1"
+    null       = "~> 3.1"
   }
 }


### PR DESCRIPTION
This upgrades the terraform and required provider versions to the latest releases. This change may be seen as too restrictive as it enforces both a minimum and maximum version but without additional testing this should be a known-good configuration that will handle situations like the `helm_repository` data source being removed.