### PR TITLE
Replace kubectl command with manifest resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 module "cert_manager" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager"
 
-  name       = "cert-manager"
-  kubeconfig = "..."
-  metrics    = true
+  name    = "cert-manager"
+  metrics = true
 }
 
 module "issuer" {

--- a/modules/issuer/README.md
+++ b/modules/issuer/README.md
@@ -10,10 +10,9 @@ server.
 module "issuer" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
 
-  name       = "issuer"
-  email      = "daniel.balcomb@gmail.com"
-  server     = "production"
-  kubeconfig = "..."
+  name   = "issuer"
+  email  = "daniel.balcomb@gmail.com"
+  server = "production"
 
   ingress = {
     class = "traefik"
@@ -28,7 +27,6 @@ module "issuer" {
 | `name`                                 | `string` |           | The certificate issuer name                                  |
 | `email`                                | `string` |           | The certificate issuer ACME registration email address       |
 | `server`                               | `string` | `staging` | The certificate issuer ACME server address                   |
-| `kubeconfig`                           | `string` |           | The Kubernetes configuration file contents                   |
 | `ingress`                              | `object` | `null`    | The ingress configuration for HTTP challenges                |
 | `ingress.class`                        | `string` |           | The ingress class used for automating the validation process |
 | `dns_zone`                             | `object` | `null`    | The DNS zone configuration for DNS challenges                |
@@ -51,6 +49,3 @@ module "issuer" {
 
 - This module evaluates the shorthand `production` and `staging` values for the
   `server` variable as the corresponding *Let's Encrypt* environment.
-- This module currently requires the `kubectl` command-line utility to be
-  installed in the `PATH` and a `kubeconfig` input for *Kubernetes*
-  authentication.

--- a/modules/issuer/variables.tf
+++ b/modules/issuer/variables.tf
@@ -14,11 +14,6 @@ variable "server" {
   type        = string
 }
 
-variable "kubeconfig" {
-  description = "The Kubernetes configuration file contents"
-  type        = string
-}
-
 variable "ingress" {
   description = "The ingress configuration for HTTP challenges"
   default     = null

--- a/modules/issuer/versions.tf
+++ b/modules/issuer/versions.tf
@@ -4,7 +4,5 @@ terraform {
   required_providers {
     azurerm    = "~> 2.83"
     kubernetes = "~> 2.6"
-    local      = "~> 2.1"
-    null       = "~> 3.1"
   }
 }

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -8,10 +8,9 @@ module "cert_manager" {
 module "issuer_http" {
   source = "../../modules/issuer"
 
-  name       = "issuer"
-  email      = "daniel.balcomb@gmail.com"
-  server     = "staging"
-  kubeconfig = "..."
+  name   = "issuer"
+  email  = "daniel.balcomb@gmail.com"
+  server = "staging"
 
   ingress = {
     class = "traefik"
@@ -21,10 +20,9 @@ module "issuer_http" {
 module "issuer_dns" {
   source = "../../modules/issuer"
 
-  name       = "issuer"
-  email      = "daniel.balcomb@gmail.com"
-  server     = "staging"
-  kubeconfig = "..."
+  name   = "issuer"
+  email  = "daniel.balcomb@gmail.com"
+  server = "staging"
 
   dns_zone = {
     name  = "example.com"


### PR DESCRIPTION
This replaces the remaining `kubectl` command used by the `issuer` module with the `kubernetes_manifest` resource.