### PR TITLE
Update documentation and test references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ module "issuer" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
 
   name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
+  email  = "user@example.com"
   server = "production"
 
   ingress = {
-    class = "traefik"
+    class = "nginx"
   }
 }
 ```

--- a/modules/issuer/README.md
+++ b/modules/issuer/README.md
@@ -11,11 +11,11 @@ module "issuer" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
 
   name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
+  email  = "user@example.com"
   server = "production"
 
   ingress = {
-    class = "traefik"
+    class = "nginx"
   }
 }
 ```

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -9,11 +9,11 @@ module "issuer_http" {
   source = "../../modules/issuer"
 
   name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
+  email  = "user@example.com"
   server = "staging"
 
   ingress = {
-    class = "traefik"
+    class = "nginx"
   }
 }
 
@@ -21,7 +21,7 @@ module "issuer_dns" {
   source = "../../modules/issuer"
 
   name   = "issuer"
-  email  = "daniel.balcomb@gmail.com"
+  email  = "user@example.com"
   server = "staging"
 
   dns_zone = {


### PR DESCRIPTION
This removes references to my personal email address from the documentation and tests. It also switches the ingress class to `nginx` as is more commonly used in the Azure Kubernetes Service documentation.