### PR TITLE
Add issuer DNS zone selector

### DIFF
--- a/modules/issuer/templates/issuer.yml
+++ b/modules/issuer/templates/issuer.yml
@@ -9,11 +9,6 @@ spec:
     privateKeySecretRef:
       name: ${ name }-key
     solvers:
-    %{~ if ingress != null ~}
-    - http01:
-        ingress:
-          class: ${ ingress.class }
-    %{~ endif ~}
     %{~ if dns != null ~}
     - dns01:
         azureDNS:
@@ -26,4 +21,12 @@ spec:
           resourceGroupName: ${ dns.zone.group }
           hostedZoneName: ${ dns.zone.name }
           environment: AzurePublicCloud
+      selector:
+        dnsZones:
+        - ${ dns.zone.name }
+    %{~ endif ~}
+    %{~ if ingress != null ~}
+    - http01:
+        ingress:
+          class: ${ ingress.class }
     %{~ endif ~}


### PR DESCRIPTION
This adds a DNS zone selector to the cluster issuer resource to support the situation where both HTTP01 and DNS01 solvers are specified. Since the DNS01 solver is already tied to the zone name this should have no effect on existing resources using the issuer.

This also moves the HTTP01 solver to the bottom as the documentation is not immediately clear which solver has precedence when one does not define a selector. The documentation suggests that if two or more matching solvers are found then the earliest will be used, hence having DNS01 before HTTP01.